### PR TITLE
Upgrade the version of depended Mariadb Chart

### DIFF
--- a/curated/wordpress/requirements.yaml
+++ b/curated/wordpress/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 5.x.x
+  version: 6.x.x
   repository: https://apphub.aliyuncs.com
   condition: mariadb.enabled
   tags:


### PR DESCRIPTION
The version 5.x.x of Chart Mariadb doesn't exist in AppHub, while
6.x.x exists. So upgrade it in order to make Chart Wordpress'
dependency is avialble when `helm dep update`