### PR TITLE
[云原生应用大赛] Tekton charts

### DIFF
--- a/submitted/tekton/.helmignore
+++ b/submitted/tekton/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/submitted/tekton/Chart.yaml
+++ b/submitted/tekton/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+name: tekton
+icon: https://avatars2.githubusercontent.com/u/47602533
+description: A Kubernetes-native pipeline resource
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: v0.5.2

--- a/submitted/tekton/README.md
+++ b/submitted/tekton/README.md
@@ -1,0 +1,43 @@
+# Tekton
+
+## 功能介绍
+
+在Kubernetes集群中安装Tekton使用环境。其中默认启用Tekton Dashboard，可以提供Pipeline的可视化界面。
+
+
+
+## 安装使用
+
+```shell
+helm install tektoncd tekton
+```
+
+运行后看到输出：
+
+```shell
+NAME: tekton
+LAST DEPLOYED: 2019-08-04 15:06:00.839105318 +0800 CST m=+0.085271389
+NAMESPACE: default
+STATUS: deployed
+
+NOTES:
+This is a 3rd-party Chart integrate tekton pipeline and dashboard with image synced to aliyun for easy access in China.
+If dashboard is enabled, to use it, run
+
+kubectl --namespace tekton-pipelines port-forward svc/tekton-dashboard 9097:9097
+
+Then you can access it through localhost:9097.
+The uninstall process will delete the whole namespace `tekton-pipelines` which may take a while to finish.
+The original project locates at https://github.com/tektoncd/pipeline and https://github.com/tektoncd/dashboard. Lots of features are comming in the future.
+NOTE: Jenkins-x-charts also has a chart for tekton locates at https://github.com/jenkins-x-charts/tekton/tree/master/tekton which does not include tekton dashboard.
+```
+
+按照NOTES提示，可以在运行`kubectl port-forward`后访问`localhost:9097`访问tekton dashboard。
+
+## 使用参数
+
+```shell
+helm install tektoncd tekton --set dashboard.port=8080,dashboard.type=NodePort
+```
+
+可以通过改变values中dashboard的参数来设置访问dashboard的方式。

--- a/submitted/tekton/templates/NOTES.txt
+++ b/submitted/tekton/templates/NOTES.txt
@@ -1,0 +1,9 @@
+This is a 3rd-party Chart integrate tekton pipeline and dashboard with image synced to aliyun for easy access in China.
+If dashboard is enabled, to use it, run
+
+kubectl --namespace {{ .Values.pipelines.namespace }} port-forward svc/tekton-dashboard 9097:{{ .Values.dashboard.port }}
+
+Then you can access it through localhost:9097.
+The uninstall process will delete the whole namespace `{{ .Values.pipelines.namespace }}` which may take a while to finish.
+The original project locates at https://github.com/tektoncd/pipeline and https://github.com/tektoncd/dashboard. Lots of features are comming in the future.
+NOTE: Jenkins-x-charts also has a chart for tekton locates at https://github.com/jenkins-x-charts/tekton/tree/master/tekton which does not include tekton dashboard.

--- a/submitted/tekton/templates/_helpers.tpl
+++ b/submitted/tekton/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tekton.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tekton.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tekton.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "tekton.labels" -}}
+app.kubernetes.io/name: {{ include "tekton.name" . }}
+helm.sh/chart: {{ include "tekton.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/submitted/tekton/templates/clusterrole-aggregate-edit.yaml
+++ b/submitted/tekton/templates/clusterrole-aggregate-edit.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: tekton-aggregate-edit
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/submitted/tekton/templates/clusterrole-aggregate-view.yaml
+++ b/submitted/tekton/templates/clusterrole-aggregate-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: tekton-aggregate-view
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - watch

--- a/submitted/tekton/templates/clusterrole-dashboard-minimal.yaml
+++ b/submitted/tekton/templates/clusterrole-dashboard-minimal.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.dashboard.enabled -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-dashboard-minimal
+  namespace: {{ .Values.pipelines.namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log", "namespaces", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "list", "create", "update", "watch", "delete"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+{{- end }}

--- a/submitted/tekton/templates/clusterrole-pipelines-admin.yaml
+++ b/submitted/tekton/templates/clusterrole-pipelines-admin.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-pipelines-admin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - namespaces
+  - secrets
+  - events
+  - serviceaccounts
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - clustertasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks/status
+  - clustertasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  - pipelineresources/status
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - tekton-pipelines
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/submitted/tekton/templates/clusterrolebinding-dashboard-minimal.yaml
+++ b/submitted/tekton/templates/clusterrolebinding-dashboard-minimal.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.dashboard.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-dashboard-minimal
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: {{ .Values.pipelines.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-minimal
+{{- end }}

--- a/submitted/tekton/templates/clusterrolebinding-pipelines-controller-admin.yaml
+++ b/submitted/tekton/templates/clusterrolebinding-pipelines-controller-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-admin
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/templates/configmap-artifact-bucket.yaml
+++ b/submitted/tekton/templates/configmap-artifact-bucket.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/templates/configmap-artifact-pvc.yaml
+++ b/submitted/tekton/templates/configmap-artifact-pvc.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: config-artifact-pvc
+  namespace: {{ .Values.pipelines.namespace }}
+data:
+  size: "{{ .Values.pipelines.pvc.size }}"

--- a/submitted/tekton/templates/configmap-defaults.yaml
+++ b/submitted/tekton/templates/configmap-defaults.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/templates/configmap-logging.yaml
+++ b/submitted/tekton/templates/configmap-logging.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  loglevel.controller: info
+  loglevel.webhook: info
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/templates/customresourcedefinition-clustertasks.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-clustertasks.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: ClusterTask
+    plural: clustertasks
+  scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-images.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-images.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  names:
+    categories:
+    - all
+    - knative-internal
+    - caching
+    kind: Image
+    plural: images
+    shortNames:
+    - img
+    singular: image
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-pipelineresources.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-pipelineresources.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: PipelineResource
+    plural: pipelineresources
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-pipelineruns.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-pipelineruns.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].status
+    name: Succeeded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].reason
+    name: Reason
+    type: string
+  - JSONPath: .status.startTime
+    name: StartTime
+    type: date
+  - JSONPath: .status.completionTime
+    name: CompletionTime
+    type: date
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: PipelineRun
+    plural: pipelineruns
+    shortNames:
+    - pr
+    - prs
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-pipelines.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-pipelines.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: Pipeline
+    plural: pipelines
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-taskruns.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-taskruns.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].status
+    name: Succeeded
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Succeeded")].reason
+    name: Reason
+    type: string
+  - JSONPath: .status.startTime
+    name: StartTime
+    type: date
+  - JSONPath: .status.completionTime
+    name: CompletionTime
+    type: date
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: TaskRun
+    plural: taskruns
+    shortNames:
+    - tr
+    - trs
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/customresourcedefinition-tasks.yaml
+++ b/submitted/tekton/templates/customresourcedefinition-tasks.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    categories:
+    - all
+    - tekton-pipelines
+    kind: Task
+    plural: tasks
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/submitted/tekton/templates/deployment-dashboard.yaml
+++ b/submitted/tekton/templates/deployment-dashboard.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.dashboard.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-dashboard
+  namespace: {{ .Values.pipelines.namespace }}
+  labels:
+    app: tekton-dashboard
+spec:
+  replicas: {{ .Values.dashboard.replicas }}
+  selector:
+    matchLabels:
+      app: tekton-dashboard
+  template:
+    metadata:
+      name: tekton-dashboard
+      labels:
+        app: tekton-dashboard
+    spec:
+      containers:
+      - name: tekton-dashboard
+        image: gcr.io/tekton-nightly/dashboard:latest
+        ports:
+        - containerPort: 9097
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9097
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9097
+        resources:
+        env:
+        - name: PORT
+          value: "9097"
+        - name: WEB_RESOURCES_DIR
+          value: /var/run/ko/web
+        - name: PIPELINE_RUN_SERVICE_ACCOUNT
+          value: ""
+        - name: INSTALLED_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      serviceAccountName: tekton-dashboard
+{{- end }}

--- a/submitted/tekton/templates/deployment-pipelines-controller.yaml
+++ b/submitted/tekton/templates/deployment-pipelines-controller.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: {{ .Values.pipelines.namespace }}
+spec:
+  replicas: {{ .Values.pipelines.controller.replicas }}
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-controller
+    spec:
+      containers:
+      - args:
+        - -logtostderr
+        - -stderrthreshold
+        - INFO
+        - -kubeconfig-writer-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-kubeconfigwriter
+        - -creds-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-creds-init
+        - -git-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-git-init
+        - -nop-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-nop
+        - -bash-noop-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-bash
+        - -gsutil-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-gsutil
+        - -entrypoint-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-entrypoint
+        - -imagedigest-exporter-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-imagedigestexporter
+        - -pr-image
+        - registry.cn-hangzhou.aliyuncs.com/somefive/tekton-pullrequest-init
+        image: registry.cn-hangzhou.aliyuncs.com/somefive/tekton-controller
+        name: tekton-pipelines-controller
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+      serviceAccountName: tekton-pipelines-controller
+      volumes:
+      - configMap:
+          name: config-logging
+        name: config-logging

--- a/submitted/tekton/templates/deployment-pipelines-webhook.yaml
+++ b/submitted/tekton/templates/deployment-pipelines-webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: {{ .Values.pipelines.namespace }}
+spec:
+  replicas: {{ .Values.pipelines.webhook.replicas }}
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-webhook
+    spec:
+      containers:
+      - image: registry.cn-hangzhou.aliyuncs.com/somefive/tekton-webhook
+        name: webhook
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+      serviceAccountName: tekton-pipelines-controller
+      volumes:
+      - configMap:
+          name: config-logging
+        name: config-logging

--- a/submitted/tekton/templates/namespace-pipelines.yaml
+++ b/submitted/tekton/templates/namespace-pipelines.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/templates/podsecuritypolicy.yaml
+++ b/submitted/tekton/templates/podsecuritypolicy.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: tekton-pipelines
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - emptyDir
+  - configMap
+  - secret

--- a/submitted/tekton/templates/service-dashboard.yaml
+++ b/submitted/tekton/templates/service-dashboard.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.dashboard.enabled -}}
+kind: Service
+apiVersion: v1
+metadata:
+  name: tekton-dashboard
+  namespace: {{ .Values.pipelines.namespace }}
+  labels:
+    app: tekton-dashboard
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.dashboard.port }}
+      targetPort: 9097
+  type: {{ .Values.dashboard.type }}
+  selector:
+    app: tekton-dashboard
+{{- end }}

--- a/submitted/tekton/templates/service-pipelines-controller.yaml
+++ b/submitted/tekton/templates/service-pipelines-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-controller
+  name: tekton-pipelines-controller
+  namespace: {{ .Values.pipelines.namespace }}
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: tekton-pipelines-controller

--- a/submitted/tekton/templates/service-pipelines-webhook.yaml
+++ b/submitted/tekton/templates/service-pipelines-webhook.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-webhook
+  name: tekton-pipelines-webhook
+  namespace: {{ .Values.pipelines.namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    app: tekton-pipelines-webhook

--- a/submitted/tekton/templates/serviceaccount-dashboard.yaml
+++ b/submitted/tekton/templates/serviceaccount-dashboard.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.dashboard.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tekton-dashboard
+  name: tekton-dashboard
+  namespace: {{ .Values.pipelines.namespace }}
+{{- end }}

--- a/submitted/tekton/templates/serviceaccount-pipelines-controller.yaml
+++ b/submitted/tekton/templates/serviceaccount-pipelines-controller.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines-controller
+  namespace: {{ .Values.pipelines.namespace }}

--- a/submitted/tekton/values.yaml
+++ b/submitted/tekton/values.yaml
@@ -1,0 +1,14 @@
+pipelines:
+  namespace: tekton-pipelines
+  controller:
+    replicas: 1
+  webhook:
+    replicas: 1
+  pvc:
+    size: 5Gi
+
+dashboard:
+  enabled: true
+  replicas: 1
+  port: 9097
+  type: ClusterIP


### PR DESCRIPTION
- 参赛队伍名称： somefive
- 参赛人： @somefive
- charts的功能：
  - 安装 [Tekton](https://tekton.dev/) 至Kubernetes集群中。
  - 包括 [tektoncd/pipeline](https://github.com/tektoncd/pipeline) 中的CRD/ServiceAccount/Roles/Controller等资源及实例
  - 可选安装 [tektoncd/dashboard](https://github.com/tektoncd/dashboard) 做可视化（默认启用）。
  - Chart内使用镜像均已同步至阿里云容器镜像仓库。
- 参赛要求
  - [x] README 文档，含功能说明、安装步骤。
  - [x] 有效性验证，已使用minikube验证