### PR TITLE
[云原生应用大赛] Django-sso-server Chart

### DIFF
--- a/submitted/django-sso-server/.helmignore
+++ b/submitted/django-sso-server/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/submitted/django-sso-server/Chart.yaml
+++ b/submitted/django-sso-server/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+name: django-sso-server
+description: A user friendly Django SSO server(一个用户友好的Django单点登录服务器)(ldap&&企业微信扫码) 
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.0.1
+
+keywords:
+- sso
+- django
+- ldap
+- python
+
+sources:
+- https://github.com/calmkart/Django-sso-server
+
+maintainers:
+- name: calmkart

--- a/submitted/django-sso-server/README.md
+++ b/submitted/django-sso-server/README.md
@@ -1,0 +1,68 @@
+# Django Sso Server
+## 一个用户友好的Django单点登录系统(ldap&&企业微信扫码)
+***
+### 1 . 功能简介:
+本系统为用于实现基于ldap验证或(和)企业微信扫码验证的单点登录系统
+
+通过加解密cookie以及验证api的方式实现单点登录
+
+### 2. 安装方式:
+```shell
+helm install django-sso-server ../django-sso-server --set ingress.hosts={sso.calmkart.com} --set nameSpace="default"
+```
+其中sso.calmkart.com可以替换为你需要的域名,nameSpace可以替换为其他命名空间
+
+运行后将看到输出并创建以下k8s api对象:
+```shell
+➜  django-sso-server helm install django-sso-server ../django-sso-server --set ingress.hosts={sso.calmkart.com}
+NAME: django-sso-server
+LAST DEPLOYED: 2019-08-07 16:50:17.156739 +0800 CST m=+0.108258958
+NAMESPACE: default
+STATUS: deployed
+
+NOTES:
+1. Get the application URL by running these commands:
+  http://sso.calmkart.com/
+
+➜  django-sso-server kubectl get pods
+NAME                                 READY   STATUS    RESTARTS   AGE
+django-sso-server-768d85864b-fvb7q   1/1     Running   0          60s
+➜  django-sso-server kubectl get service
+NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+django-sso-server   ClusterIP   10.103.253.185   <none>        8080/TCP   65s
+kubernetes          ClusterIP   10.96.0.1        <none>        443/TCP    2d4h
+➜  django-sso-server kubectl get deployment
+NAME                READY   UP-TO-DATE   AVAILABLE   AGE
+django-sso-server   1/1     1            1           68s
+➜  django-sso-server kubectl get ingress
+NAME                HOSTS              ADDRESS   PORTS   AGE
+django-sso-server   sso.calmkart.com             80      71s
+```
+
+我们将sso.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
+
+访问地址:
+`http://sso.calmkart.com/`
+
+### 3. 其他备注
+
+#### 可用参数
+
+- ingress.hosts
+
+`ingress对象对应的域名`
+
+- nameSpace
+
+`django-sso-server部署所在的namespace`
+
+#### 详细使用说明
+[https://github.com/calmkart/Django-sso-server/blob/master/README.MD](https://github.com/calmkart/Django-sso-server/blob/master/README.MD)
+
+#### 系统源码
+
+[https://github.com/calmkart/Django-sso-server](https://github.com/calmkart/Django-sso-server)
+
+#### docker镜像
+
+[https://hub.docker.com/r/calmkart/django_sso_server](https://hub.docker.com/r/calmkart/django_sso_server)

--- a/submitted/django-sso-server/templates/NOTES.txt
+++ b/submitted/django-sso-server/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "django-sso-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "django-sso-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ template "django-sso-server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app={{ template "django-sso-server.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/submitted/django-sso-server/templates/_helpers.tpl
+++ b/submitted/django-sso-server/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "django-sso-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "django-sso-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "django-sso-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "django-sso-server.labels" -}}
+app.kubernetes.io/name: {{ include "django-sso-server.name" . }}
+helm.sh/chart: {{ include "django-sso-server.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/submitted/django-sso-server/templates/deployment.yaml
+++ b/submitted/django-sso-server/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "django-sso-server.fullname" . }}
+  namespace: {{ .Values.nameSpace }}
+  labels:
+{{ include "django-sso-server.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "django-sso-server.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "django-sso-server.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/submitted/django-sso-server/templates/ingress.yaml
+++ b/submitted/django-sso-server/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "django-sso-server.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Values.nameSpace }}
+  labels:
+{{ include "django-sso-server.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/submitted/django-sso-server/templates/service.yaml
+++ b/submitted/django-sso-server/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "django-sso-server.fullname" . }}
+  namespace: {{ .Values.nameSpace }}
+  labels:
+{{ include "django-sso-server.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "django-sso-server.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/submitted/django-sso-server/values.yaml
+++ b/submitted/django-sso-server/values.yaml
@@ -1,0 +1,47 @@
+# Default values for django-sso-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: calmkart/django_sso_server
+  tag: v0.0.1
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+nameSpace: "default"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  annotations: {}
+  path: /
+  hosts:
+    - 'sso.calmkart.com'
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
- 参赛队伍名称： calmkart
- 参赛人： @calmkart
- charts的功能：

    一个Django编写且用户友好的单点登录系统(支持ldap和企业微信扫码登录)
    应用源码地址: [https://github.com/calmkart/Django-sso-server](https://github.com/calmkart/Django-sso-server)

- 参赛要求
- [x] [README文档](https://github.com/calmkart/charts/blob/calmkart/submitted/django-sso-server/README.md)


- [x] 有效性验证(已使用minikube验证)