### PR TITLE
[云原生应用大赛] gohttpserver Chart

### DIFF
--- a/submitted/gohttpserver/.helmignore
+++ b/submitted/gohttpserver/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/submitted/gohttpserver/Chart.yaml
+++ b/submitted/gohttpserver/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+name: gohttpserver
+description: 一个用户友好的HTTP文件服务器
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.0.1
+
+keywords:
+- golang
+- httpserver
+- Fileserver
+
+icon: https://raw.githubusercontent.com/codeskyblue/gohttpserver/master/assets/favicon.png
+
+sources:
+- https://github.com/codeskyblue/gohttpserver
+- https://hub.docker.com/r/codeskyblue/gohttpserver

--- a/submitted/gohttpserver/README.md
+++ b/submitted/gohttpserver/README.md
@@ -1,0 +1,72 @@
+# gohttpserver
+
+## 功能介绍:
+
+目标: 做最好的HTTP文件服务器
+
+功能: 人性化的UI体验，文件的上传支持，安卓和苹果安装包的二维码直接生成。
+
+项目作者源码: [https://github.com/codeskyblue/gohttpserver](https://github.com/codeskyblue/gohttpserver)
+
+基于原作者的docker镜像做了helm包封装.可以做到开箱即用.
+
+
+## 安装方式:
+```shell
+helm install gohttpserver ../gohttpserver 
+```
+
+运行后将看到输出并创建以下k8s api对象:
+```shell
+➜  gohttpserver git:(gohttpserver) ✗ helm install gohttpserver ../gohttpserver
+NAME: gohttpserver
+LAST DEPLOYED: 2019-08-08 15:17:21.380347 +0800 CST m=+0.144642186
+NAMESPACE: default
+STATUS: deployed
+
+NOTES:
+1. Get the application URL by running these commands:
+  http://gohttpserver.calmkart.com/
+
+➜  gohttpserver git:(gohttpserver) ✗ kubectl get pods
+NAME                                 READY   STATUS        RESTARTS   AGE
+gohttpserver-55fc8964d8-6nsm2        1/1     Running       0          69s
+➜  gohttpserver git:(gohttpserver) ✗ kubectl get deployment
+NAME           READY   UP-TO-DATE   AVAILABLE   AGE
+gohttpserver   1/1     1            1           75s
+➜  gohttpserver git:(gohttpserver) ✗ kubectl get service
+NAME           TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
+gohttpserver   ClusterIP   10.96.80.28   <none>        8000/TCP   79s
+➜  gohttpserver git:(gohttpserver) ✗ kubectl get ingress
+NAME           HOSTS                       ADDRESS   PORTS   AGE
+gohttpserver   gohttpserver.calmkart.com             80      85s
+```
+
+我们可以通过port-forward或者ingress访问服务
+
+>`kubectl port-forward svc/gohttpserver 8000:8000`
+- 访问地址 `http://0.0.0.0:8000/`
+
+>将gohttpserver.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
+- 访问地址: `http://gohttpserver.calmkart.com/`
+
+### 3. 其他备注
+
+#### 可用参数
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `pullPolicy` | docker镜像拉取策略(因为tag使用的是latest,所以推荐使用默认的Always,调试或特殊情况可修改) |`Always`|
+| `nameSpace` | gohttpserver创建的api对象的命名空间 |`"default"`|
+| `startArgs.auth_type` | 认证方式,参考项目源官方文档,推荐为空不设置,或设置为http | `''` |
+| `startArgs.auth_http` | http认证的账号密码,以:分隔(如calmkart:calmkart),细节参考官方文档 | `''` |
+| `startArgs.upload` | 是否开启上传功能,默认为true | `true` |
+| `startArgs.delete` | 是否开启删除功能,默认为true | `true` |
+| `ingress.hosts` | ingress域名 | `['gohttpserver.calmkart.com']` |
+
+#### 系统源码
+
+[https://github.com/codeskyblue/gohttpserver](https://github.com/codeskyblue/gohttpserver)
+
+#### docker镜像
+
+[https://hub.docker.com/r/codeskyblue/gohttpserver](https://hub.docker.com/r/codeskyblue/gohttpserver)

--- a/submitted/gohttpserver/templates/NOTES.txt
+++ b/submitted/gohttpserver/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "gohttpserver.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "gohttpserver.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ template "gohttpserver.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app={{ template "gohttpserver.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/submitted/gohttpserver/templates/_helpers.tpl
+++ b/submitted/gohttpserver/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gohttpserver.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gohttpserver.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gohttpserver.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "gohttpserver.labels" -}}
+app.kubernetes.io/name: {{ include "gohttpserver.name" . }}
+helm.sh/chart: {{ include "gohttpserver.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/submitted/gohttpserver/templates/deployment.yaml
+++ b/submitted/gohttpserver/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "gohttpserver.fullname" . }}
+  namespace: {{ .Values.nameSpace }}
+  labels:
+{{ include "gohttpserver.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "gohttpserver.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "gohttpserver.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["{{ .Values.startCommand }}"]
+          args: 
+          - "--root={{ .Values.startArgs.root }}"
+          {{if .Values.startArgs.auth_type -}}
+          - "--auth-type={{ .Values.startArgs.auth_type }}"
+          {{- end }}
+          {{if .Values.startArgs.auth_http }}
+          - "--auth-http={{ .Values.startArgs.auth_http }}"
+          {{- end }}
+          {{if .Values.startArgs.upload -}}
+          - "--upload"
+          {{- end }}
+          {{if .Values.startArgs.delete -}}
+          - "--delete"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/submitted/gohttpserver/templates/ingress.yaml
+++ b/submitted/gohttpserver/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "gohttpserver.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "gohttpserver.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/submitted/gohttpserver/templates/service.yaml
+++ b/submitted/gohttpserver/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gohttpserver.fullname" . }}
+  namepace: {{ .Values.nameSpace }}
+  labels:
+{{ include "gohttpserver.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "gohttpserver.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/submitted/gohttpserver/values.yaml
+++ b/submitted/gohttpserver/values.yaml
@@ -1,0 +1,58 @@
+# Default values for django-sso-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: codeskyblue/gohttpserver
+  tag: latest
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+nameSpace: "default"
+
+startCommand:
+  '/app/gohttpserver'
+startArgs:
+  root: '/app/public'
+  auth_type: ''
+  auth_http: ''
+  upload: true
+  delete: true
+
+
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: true
+  annotations: {}
+  path: /
+  hosts:
+    - 'gohttpserver.calmkart.com'
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
参赛队伍名称： calmkart

参赛人： @calmkart

charts的功能：

一个用户友好的HTTP文件服务器(应用于文件分享)
应用源码地址: https://github.com/codeskyblue/gohttpserver

参赛要求
- [x] [README文档](https://github.com/calmkart/charts/blob/gohttpserver/submitted/gohttpserver/README.md)

- [x] 有效性验证(已使用minikube验证)