### PR TITLE
[云原生应用大赛] Redispapa Chart

### DIFF
--- a/submitted/redispapa/.helmignore
+++ b/submitted/redispapa/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/submitted/redispapa/Chart.yaml
+++ b/submitted/redispapa/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+name: redispapa
+description: 利用redis的info信息对redis的使用情况进行监控的一个系统.(动态目标发现增强版,从原系统的读conf修改为动态发现)
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.0.1
+
+keywords:
+- redispapa
+- redis
+- monitor
+- dynamic
+
+
+icon: https://github.com/calmkart/redispapa/blob/master/doge.ico
+
+sources:
+- https://github.com/calmkart/redispapa
+- https://github.com/no13bus/redispapa

--- a/submitted/redispapa/README.md
+++ b/submitted/redispapa/README.md
@@ -1,4 +1,4 @@
-# gohttpserver
+# redispapa
 
 ## 功能介绍:
 
@@ -17,7 +17,7 @@
 
 ## 安装方式:
 ```shell
-helm install gohttpserver ../gohttpserver 
+helm install redispapa ../redispapa 
 ```
 
 运行后将看到输出并创建以下k8s api对象:
@@ -62,7 +62,7 @@ redispapa   redispapa.calmkart.com             80      2m51s
 #### 可用参数
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
-| `nameSpace` | gohttpserver创建的api对象的命名空间 |`"default"`|
+| `nameSpace` | redispapa创建的api对象的命名空间 |`"default"`|
 | `ingress.hosts` | ingress域名 | `['redispapa.calmkart.com']` |
 
 #### 详细使用说明

--- a/submitted/redispapa/README.md
+++ b/submitted/redispapa/README.md
@@ -22,15 +22,17 @@ helm install redispapa ../redispapa
 
 运行后将看到输出并创建以下k8s api对象:
 ```shell
-➜  redispapa git:(redispapa) ✗ helm install redispapa ../redispapa
+➜  redispapa git:(redispapa) ✗ helm install redispapa ../redispapa  --set service.type=NodePort
 NAME: redispapa
-LAST DEPLOYED: 2019-08-12 12:21:23.994296 +0800 CST m=+0.152074387
+LAST DEPLOYED: 2019-08-12 17:10:29.032902 +0800 CST m=+0.138064656
 NAMESPACE: default
 STATUS: deployed
 
 NOTES:
 1. Get the application URL by running these commands:
-  http://redispapa.calmkart.com/
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services redispapa)
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
 
 ➜  redispapa git:(redispapa) ✗ kubectl get pods
 kNAME                      READY   STATUS    RESTARTS   AGE
@@ -42,12 +44,13 @@ redispapa   1/1     1            1           2m46s
 NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
 kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP    7d
 redispapa    ClusterIP   10.110.99.224   <none>        5000/TCP   2m50s
-➜  redispapa git:(redispapa) ✗ kubectl get ingress
-NAME        HOSTS                    ADDRESS   PORTS   AGE
-redispapa   redispapa.calmkart.com             80      2m51s
 ```
 
-我们可以通过port-forward或者ingress访问服务
+我们可以通过NodePort或者port-forward或者ingress访问服务
+
+>`NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services redispapa)&&NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")&&echo http://$NODE_IP:$NODE_PORT`
+- 访问地址(监控页面): `<nodeip:nodeport>`
+- 访问地址(target后台管理): `<nodeip:nodeport>/admin/redisobj`
 
 >`kubectl port-forward svc/redispapa 5000:5000`
 - 访问地址(监控页面): `http://0.0.0.0:5000/`
@@ -63,6 +66,8 @@ redispapa   redispapa.calmkart.com             80      2m51s
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `nameSpace` | redispapa创建的api对象的命名空间 |`"default"`|
+| `service.type` | service服务暴露类型 | `ClusterIP` |
+| `ingress.enabled` | 是否开启ingress | `false` |
 | `ingress.hosts` | ingress域名 | `['redispapa.calmkart.com']` |
 
 #### 详细使用说明

--- a/submitted/redispapa/README.md
+++ b/submitted/redispapa/README.md
@@ -17,12 +17,12 @@
 
 ## 安装方式:
 ```shell
-helm install redispapa ../redispapa 
+helm install redispapa ./redispapa 
 ```
 
 运行后将看到输出并创建以下k8s api对象:
 ```shell
-➜  redispapa git:(redispapa) ✗ helm install redispapa ../redispapa  --set service.type=NodePort
+➜ helm install redispapa ./redispapa  --set service.type=NodePort
 NAME: redispapa
 LAST DEPLOYED: 2019-08-12 17:10:29.032902 +0800 CST m=+0.138064656
 NAMESPACE: default
@@ -34,13 +34,13 @@ NOTES:
   export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 
-➜  redispapa git:(redispapa) ✗ kubectl get pods
+➜ kubectl get pods
 kNAME                      READY   STATUS    RESTARTS   AGE
 redispapa-5bb76fd-tw4zj   1/1     Running   0          2m41s
-➜  redispapa git:(redispapa) ✗ kubectl get deployments
+➜ kubectl get deployments
 NAME        READY   UP-TO-DATE   AVAILABLE   AGE
 redispapa   1/1     1            1           2m46s
-➜  redispapa git:(redispapa) ✗ kubectl get service
+➜ kubectl get service
 NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
 kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP    7d
 redispapa    ClusterIP   10.110.99.224   <none>        5000/TCP   2m50s
@@ -48,15 +48,16 @@ redispapa    ClusterIP   10.110.99.224   <none>        5000/TCP   2m50s
 
 我们可以通过NodePort或者port-forward或者ingress访问服务
 
->`NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services redispapa)&&NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")&&echo http://$NODE_IP:$NODE_PORT`
+NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services redispapa)&&NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")&&echo http://$NODE_IP:$NODE_PORT
+
 - 访问地址(监控页面): `<nodeip:nodeport>`
 - 访问地址(target后台管理): `<nodeip:nodeport>/admin/redisobj`
 
->`kubectl port-forward svc/redispapa 5000:5000`
+kubectl port-forward svc/redispapa 5000:5000
 - 访问地址(监控页面): `http://0.0.0.0:5000/`
 - 访问地址(target后台管理): `http://0.0.0.0:5000/admin/redisobj`
 
->将redispapa.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
+将redispapa.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
 - 访问地址(监控页面): `http://redispapa.calmkart.com/`
 - 访问地址(target后台管理): `http://redispapa.calmkart.com/admin/redisobj`
 

--- a/submitted/redispapa/README.md
+++ b/submitted/redispapa/README.md
@@ -1,0 +1,77 @@
+# gohttpserver
+
+## 功能介绍:
+
+功能: 利用redis的info信息对redis的使用情况进行监控。(相较于原版的读conf获取target,纯静态修改需要重启的方式,修改为动态读取数据库更新线程列表.并且替换了原版所有不能用的cdn静态文件.)
+
+改动: 
+- 从原系统的读config文件获取监控target列表(静态,需手动修改并重启服务器)切换到sqlite动态发现(通过管理后台变更数据,无需重启)
+
+- 添加了flask admin管理后台用于动态变更监控target列表
+
+- 原版的静态文件用的cdn地址已有很多读取不上了,全部替换成了本地文件
+
+源码地址:
+
+[https://github.com/calmkart/redispapa](https://github.com/calmkart/redispapa)
+
+## 安装方式:
+```shell
+helm install gohttpserver ../gohttpserver 
+```
+
+运行后将看到输出并创建以下k8s api对象:
+```shell
+➜  redispapa git:(redispapa) ✗ helm install redispapa ../redispapa
+NAME: redispapa
+LAST DEPLOYED: 2019-08-12 12:21:23.994296 +0800 CST m=+0.152074387
+NAMESPACE: default
+STATUS: deployed
+
+NOTES:
+1. Get the application URL by running these commands:
+  http://redispapa.calmkart.com/
+
+➜  redispapa git:(redispapa) ✗ kubectl get pods
+kNAME                      READY   STATUS    RESTARTS   AGE
+redispapa-5bb76fd-tw4zj   1/1     Running   0          2m41s
+➜  redispapa git:(redispapa) ✗ kubectl get deployments
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+redispapa   1/1     1            1           2m46s
+➜  redispapa git:(redispapa) ✗ kubectl get service
+NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+kubernetes   ClusterIP   10.96.0.1       <none>        443/TCP    7d
+redispapa    ClusterIP   10.110.99.224   <none>        5000/TCP   2m50s
+➜  redispapa git:(redispapa) ✗ kubectl get ingress
+NAME        HOSTS                    ADDRESS   PORTS   AGE
+redispapa   redispapa.calmkart.com             80      2m51s
+```
+
+我们可以通过port-forward或者ingress访问服务
+
+>`kubectl port-forward svc/redispapa 5000:5000`
+- 访问地址(监控页面): `http://0.0.0.0:5000/`
+- 访问地址(target后台管理): `http://0.0.0.0:5000/admin/redisobj`
+
+>将redispapa.calmkart.com的域名解析切换到ingress地址即可访问(修改hosts或dns皆可)
+- 访问地址(监控页面): `http://redispapa.calmkart.com/`
+- 访问地址(target后台管理): `http://redispapa.calmkart.com/admin/redisobj`
+
+### 3. 其他备注
+
+#### 可用参数
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `nameSpace` | gohttpserver创建的api对象的命名空间 |`"default"`|
+| `ingress.hosts` | ingress域名 | `['redispapa.calmkart.com']` |
+
+#### 详细使用说明
+[https://github.com/calmkart/redispapa/blob/master/README.md](https://github.com/calmkart/redispapa/blob/master/README.md)
+
+#### 系统源码
+
+[https://github.com/calmkart/redispapa](https://github.com/calmkart/redispapa)
+
+#### docker镜像
+
+[https://cloud.docker.com/repository/docker/calmkart/redispapa-sqlite](https://cloud.docker.com/repository/docker/calmkart/redispapa-sqlite)

--- a/submitted/redispapa/templates/NOTES.txt
+++ b/submitted/redispapa/templates/NOTES.txt
@@ -13,7 +13,7 @@
   export SERVICE_IP=$(kubectl get svc {{ template "redispapa.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods -l "app={{ template "redispapa.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward svc/redispapa 5000:5000
+
+  Visit http://127.0.0.1:5000 to use your application
 {{- end }}

--- a/submitted/redispapa/templates/NOTES.txt
+++ b/submitted/redispapa/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "redispapa.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "redispapa.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ template "redispapa.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app={{ template "redispapa.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/submitted/redispapa/templates/_helpers.tpl
+++ b/submitted/redispapa/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redispapa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redispapa.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redispapa.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "redispapa.labels" -}}
+app.kubernetes.io/name: {{ include "redispapa.name" . }}
+helm.sh/chart: {{ include "redispapa.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/submitted/redispapa/templates/deployment.yaml
+++ b/submitted/redispapa/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "redispapa.fullname" . }}
+  namepace: {{ .Values.nameSpace }}
+  labels:
+{{ include "redispapa.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "redispapa.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "redispapa.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/submitted/redispapa/templates/ingress.yaml
+++ b/submitted/redispapa/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "redispapa.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "redispapa.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/submitted/redispapa/templates/service.yaml
+++ b/submitted/redispapa/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "redispapa.fullname" . }}
+  namepace: {{ .Values.nameSpace }}
+  labels:
+{{ include "redispapa.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "redispapa.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/submitted/redispapa/values.yaml
+++ b/submitted/redispapa/values.yaml
@@ -18,7 +18,7 @@ service:
   port: 5000
 
 ingress:
-  enabled: true
+  enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/submitted/redispapa/values.yaml
+++ b/submitted/redispapa/values.yaml
@@ -1,0 +1,49 @@
+# Default values for redispapa.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: calmkart/redispapa-sqlite
+  tag: v0.0.1
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+nameSpace: "default"
+
+service:
+  type: ClusterIP
+  port: 5000
+
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - redispapa.calmkart.com
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
参赛队伍名称： calmkart

参赛人： @calmkart

charts的功能：

利用redis的info信息对redis的使用情况进行监控。(相较于原版的读conf获取target,纯静态修改需要重启的方式,修改为动态读取数据库更新线程列表.并且替换了原版所有不能用的cdn静态文件.)

应用源码地址: https://github.com/calmkart/redispapa

参赛要求

- [x] [README文档](https://github.com/calmkart/charts/blob/redispapa/submitted/redispapa/README.md)

- [x] 有效性验证(已使用minikube验证)