### PR TITLE
修复 hugo chart 信息 && 增加 kk-grafana-cms helm chart

### DIFF
--- a/submitted/hugo/Chart.yaml
+++ b/submitted/hugo/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
 - golang
 icon: https://raw.githubusercontent.com/gohugoio/hugo/master/docs/static/img/hugo-logo-med.png
 sources:
-- https://github.com/kube-incubator/redis-operator
+- https://github.com/cloudnativeapp/charts/tree/master/submitted/hugo
 maintainers:
 - name: GuoXudong
   email: sunnydog0826@gmail.com

--- a/submitted/kk-grafana-cms/.helmignore
+++ b/submitted/kk-grafana-cms/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/submitted/kk-grafana-cms/Chart.yaml
+++ b/submitted/kk-grafana-cms/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: kk-grafana-cms
+description: Aliyun CMS Grafana Dashboard
+type: application
+version: 0.2.0
+appVersion: 6.4.2
+keywords:
+- grafana
+- aliyun
+- cms
+icon: https://raw.githubusercontent.com/grafana/grafana/master/docs/logo-horizontal.png
+sources:
+- https://github.com/sunny0826/cms-grafana-builder
+maintainers:
+- name: GuoXudong
+  email: sunnydog0826@gmail.com
+

--- a/submitted/kk-grafana-cms/README.md
+++ b/submitted/kk-grafana-cms/README.md
@@ -1,0 +1,63 @@
+# cms-grafana-builder
+
+![grafana](https://raw.githubusercontent.com/grafana/grafana/master/docs/logo-horizontal.png)
+
+The open-source platform for monitoring and observability.
+
+## Introduction
+
+This chart helps you run a grafana server that include aliyun cms dashboard.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+# start
+$ helm install my-release kk-grafana-cms \
+--namespace {your_namespace} \
+--set access_key_id={your_access_key_id} \
+--set access_secret={your_access_secret} \
+--set region_id={your_aliyun_region_id} \
+--set password={admin_password}
+
+# set ingress and open tls
+helm install my-release kk-grafana-cms \
+--namespace {your_namespace} \
+--set access_key_id={your_access_key_id} \
+--set access_secret={your_access_secret} \
+--set region_id={your_aliyun_region_id} \
+--set password={admin_password} \
+--set ingress.enabled=true \
+--set ingress.hosts[0].host="{your_host}",ingress.hosts[0].paths[0]="/"
+--set ingress.tls[0].secretName="{your_tls_secret_name}",ingress.tls[0].hosts[0]="{your_tls_host}"
+```
+__Please resolve the DNS to ingress.__
+
+## Uninstall
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm uninstall my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the kk-grafana-cms chart and their default values.
+
+Parameter                 	 	| Description                        				| Default
+------------------------------- | ------------------------------------------------- | ----------------------------------------------------------
+`plugins`           	        | Grafana plugin list.         	            		| `grafana-clock-panel,ryantxu-ajax-panel,farski-blendstat-panel,grafana-simple-json-datasource,https://github.com/aliyun/aliyun-cms-grafana/archive/master.zip;aliyun-cms-grafana`
+`access_key_id`                	| Aliyun Access Key Id.                  			| ``
+`access_secret`                	| Aliyun Access Secret.                  			| ``
+`region_id`                    	| Aliyun Region Id.                        			| `cn-shanghai`
+`password`                    	| Grafana admin password.                  			| `admin`
+`schedule`                    	| CronJob schedule.                     			| `"30 2 * * *"`
+`image.repository`           	| Image source repository name.         			| `registry-vpc.cn-shanghai.aliyuncs.com/keking/grafana`
+`image.pullPolicy`         		| Image pull policy                  				| `IfNotPresent`
+`build_image.repository`        | Build image source repository name.         	    | `registry-vpc.cn-shanghai.aliyuncs.com/keking/grafana-build`
+`build_image.tag`              	| Image tag.                    		  	    	| `3`
+`build_image.pullPolicy`       	| Image pull policy                  				| `IfNotPresent`
+`ingress.enabled`         		| Whether to open ingress.             				| `false`
+`ingress.hosts`          		| Ingress hosts.                       				| `[]`

--- a/submitted/kk-grafana-cms/templates/NOTES.txt
+++ b/submitted/kk-grafana-cms/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kk-grafana-cms.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "kk-grafana-cms.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ template "kk-grafana-cms.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods -l "app={{ template "kk-grafana-cms.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/submitted/kk-grafana-cms/templates/_helpers.tpl
+++ b/submitted/kk-grafana-cms/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kk-grafana-cms.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kk-grafana-cms.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kk-grafana-cms.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kk-grafana-cms.labels" -}}
+app.kubernetes.io/name: {{ include "kk-grafana-cms.name" . }}
+helm.sh/chart: {{ include "kk-grafana-cms.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/submitted/kk-grafana-cms/templates/cronjob.yaml
+++ b/submitted/kk-grafana-cms/templates/cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "cms-cronjob"
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+spec:
+  schedule: {{ .Values.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Chart.Name }}-sa
+          imagePullSecrets:
+          - name: registry-pull-secret
+          restartPolicy: OnFailure
+          containers:
+          - name: cronejob
+            image: "{{ .Values.build_image.repository}}:{{ .Values.build_image.tag }}"
+            command: ["cmsbuilder"]
+            env:
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cms-secret
+                  key: accessKeyId
+            - name: ACCESS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: cms-secret
+                  key: accessSecret
+            - name: REGION_ID
+              value: {{ .Values.region_id }}
+            - name: INIT_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace

--- a/submitted/kk-grafana-cms/templates/deployment.yaml
+++ b/submitted/kk-grafana-cms/templates/deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "kk-grafana-cms.fullname" . }}
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kk-grafana-cms.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kk-grafana-cms.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Chart.Name }}-sa
+      imagePullSecrets:
+      - name: registry-pull-secret
+      initContainers:
+      - name: init
+        image: "{{ .Values.build_image.repository}}:{{ .Values.build_image.tag }}"
+        imagePullPolicy: {{ .Values.build_image.pullPolicy }}
+        env:
+        - name: ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: cms-secret
+              key: accessKeyId
+        - name: ACCESS_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: cms-secret
+              key: accessSecret
+        - name: REGION_ID
+          value: {{ .Values.region_id }}
+        - name: INIT_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        command: ["cmsbuilder"]
+{{/*        args:*/}}
+{{/*          - --out-path*/}}
+{{/*          - /work-dir*/}}
+{{/*        volumeMounts:*/}}
+{{/*        - name: workdir*/}}
+{{/*          mountPath: "/work-dir"*/}}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: GF_INSTALL_PLUGINS
+            value: {{ .Values.plugins }}
+          - name: GF_SECURITY_ADMIN_PASSWORD__FILE
+            value: /var/local/secrets/admin_password
+          ports:
+            - name: web
+              containerPort: 3000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: web
+          volumeMounts:
+          - mountPath: /var/lib/grafana
+            name: grafana-storage
+{{/*          - name: workdir*/}}
+{{/*            mountPath: /var/lib/grafana/cms-dashboards*/}}
+          - mountPath: /etc/grafana/provisioning/dashboards/all.yaml
+            name: grafana-provisionings
+            subPath: dashboards.yaml
+          - name: pass
+            mountPath: /var/local
+            readOnly: true
+          - name: datasource
+            mountPath: /etc/grafana/provisioning/datasources/all.yaml
+            subPath: all.yaml
+          - name: grafana-dashboards
+            mountPath: /var/lib/grafana/cms-dashboards
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - args:
+          - nginx
+          - -g
+          - daemon off;
+          - -c
+          - /nginx/nginx.conf
+          image: nginx:1.15.8-alpine
+          imagePullPolicy: IfNotPresent
+          name: grafana-proxy
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            runAsGroup: 101
+            runAsUser: 100
+          volumeMounts:
+          - mountPath: /nginx/
+            name: grafana-nginx
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+      - emptyDir: {}
+        name: workdir
+      - emptyDir: {}
+        name: grafana-storage
+      - name: datasource
+        secret:
+          secretName: cms-secret
+          items:
+          - key: datasources.yaml
+            path: all.yaml
+            mode: 511
+      - name: pass
+        secret:
+          secretName: cms-secret
+          items:
+          - key: adminPass
+            path: secrets/admin_password
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: nginx.conf
+            mode: 438
+            path: nginx.conf
+          name: grafana-cms-nginx
+        name: grafana-nginx
+      - configMap:
+          defaultMode: 420
+          name: grafana-cms-provisionings
+        name: grafana-provisionings
+      - configMap:
+          defaultMode: 420
+          name: grafana-cms-dashboards
+        name: grafana-dashboards
+

--- a/submitted/kk-grafana-cms/templates/grafana-configmap.yaml
+++ b/submitted/kk-grafana-cms/templates/grafana-configmap.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "grafana-cms-provisionings"
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+
+    providers:
+     - name: ALIYUN_CMS
+       orgId: 1
+       folder: '阿里云监控'
+       type: file
+       updateIntervalSeconds: 180
+       options:
+         path: /var/lib/grafana/cms-dashboards
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "grafana-cms-dashboards"
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+data: {}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "grafana-cms-metric"
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+data:
+  ecs: |-
+    {"metric_list":[
+      {"field": "cpu_total", "name": "CPU 使用率", "format": "percent", "redline": "80"},
+      {"field": "memory_usedutilization", "name": "内存使用率", "format": "percent", "redline": "80"},
+      {"field": "diskusage_utilization", "name": "磁盘使用率", "format": "percent", "redline": "80"},
+      {"field": "IntranetInRate", "name": "私网流入带宽", "format": "bps", "redline": "1000"},
+      {"field": "IntranetOutRate", "name": "私网流出带宽", "format": "bps", "redline": "1000"},
+      {"field": "DiskReadIOPS", "name": "系统磁盘读IOPS", "format": "cps", "redline": "1000"},
+      {"field": "DiskWriteIOPS", "name": "系统磁盘写IOPS", "format": "cps", "redline": "1000"}
+    ]}
+
+  eip: |-
+    {"metric_list":[
+      {"field": "net_tx.rate", "name": "流出带宽", "format": "bps", "redline": "8000000", "ycol": "Value"},
+      {"field": "net_rx.rate", "name": "流入带宽", "format": "bps", "redline": "8000000", "ycol": "Value"},
+      {"field": "net_txPkgs.rate", "name": "每秒流出数据包数", "format": "cps", "redline": "150000", "ycol": "Value"},
+      {"field": "net_rxPkgs.rate", "name": "每秒流入数据包数", "format": "cps", "redline": "150000", "ycol": "Value"},
+      {"field": "out_ratelimit_drop_speed", "name": "限速丢包速率", "format": "percent", "redline": "5","ycol": "Average"}
+    ]}
+
+  rds: |-
+    {"metric_list":[
+      {"field": "CpuUsage", "name": "CPU使用率", "format": "percent"},
+      {"field": "DiskUsage", "name": "磁盘使用率", "format": "percent"},
+      {"field": "IOPSUsage", "name": "IOPS使用率", "format": "percent"},
+      {"field": "ConnectionUsage", "name": "连接数使用率", "format": "percent"},
+      {"field": "DataDelay", "name": "只读实例延迟", "format": "s"},
+      {"field": "MemoryUsage", "name": "内存使用率", "format": "percent"},
+      {"field": "MySQL_NetworkOutNew", "name": "Mysql每秒网络出流量", "format": "bps"},
+      {"field": "MySQL_NetworkInNew", "name": "Mysql每秒网络入流量", "format": "bps"},
+      {"field": "MySQL_ActiveSessions", "name": "Mysql当前活跃Sessions数", "format": "short"}
+    ]}
+
+  redis: |-
+    {"metric_list":[
+      {"field": "StandardCpuUsage", "name": "CPU 使用率", "format": "percent", "redline": "80"},
+      {"field": "StandardMemoryUsage", "name": "内存使用率", "format": "percent", "redline": "80"},
+      {"field": "StandardQPSUsage", "name": "QPS使用率", "format": "percent", "redline": "80"},
+      {"field": "StandardConnectionUsage", "name": "连接数使用率", "format": "percent", "redline": "80"},
+      {"field": "StandardUsedConnection", "name": "已用连接数", "format": "short", "redline": "1000"},
+      {"field": "StandardUsedQPS", "name": "平均每秒访问次数", "format": "short", "redline": "1000"},
+      {"field": "StandardAvgRt", "name": "平均响应时间", "format": "µs", "redline": "1000"},
+      {"field": "StandardMaxRt", "name": "最大响应时间", "format": "µs", "redline": "5000"},
+      {"field": "StandardIntranetIn", "name": "流入带宽", "format": "bps", "redline": "1000"},
+      {"field": "StandardIntranetInRatio", "name": "流入带宽使用率", "format": "percent", "redline": "80"},
+      {"field": "StandardIntranetOut", "name": "流出带宽", "format": "bps", "redline": "80"},
+      {"field": "StandardKeys", "name": "缓存内 Key 数量", "format": "short", "redline": "80000"}
+    ]}

--- a/submitted/kk-grafana-cms/templates/ingress.yaml
+++ b/submitted/kk-grafana-cms/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kk-grafana-cms.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/submitted/kk-grafana-cms/templates/nginx-configmap.yaml
+++ b/submitted/kk-grafana-cms/templates/nginx-configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "grafana-cms-nginx"
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+data:
+  nginx.conf: |
+    worker_processes      auto;
+    error_log             /dev/stdout warn;
+    pid                   /var/cache/nginx/nginx.pid;
+
+    events {
+       worker_connections 1024;
+    }
+
+    http {
+      include       /etc/nginx/mime.types;
+      log_format    main '[$time_local - $status] $remote_addr - $remote_user $request ($http_referer)';
+
+      proxy_connect_timeout       10;
+      proxy_read_timeout          180;
+      proxy_send_timeout          5;
+      proxy_buffering             off;
+      proxy_cache_path            /var/cache/nginx/cache levels=1:2 keys_zone=my_zone:100m inactive=1d max_size=10g;
+
+      server {
+        listen          8080;
+        access_log      off;
+
+        gzip            on;
+        gzip_min_length 1k;
+        gzip_comp_level 2;
+        gzip_types      text/plain application/javascript application/x-javascript text/css application/xml text/javascript image/jpeg image/gif image/png;
+        gzip_vary       on;
+        gzip_disable    "MSIE [1-6]\.";
+
+        proxy_set_header Host $host;
+
+        location /api/dashboards {
+          proxy_pass     http://localhost:3000;
+        }
+
+        location /api/search {
+          proxy_pass     http://localhost:3000;
+
+          sub_filter_types application/json;
+          sub_filter_once off;
+          sub_filter '"url":"/d' '"url":"d';
+        }
+
+        location / {
+          proxy_cache         my_zone;
+          proxy_cache_valid   200 302 1d;
+          proxy_cache_valid   301 30d;
+          proxy_cache_valid   any 5m;
+          proxy_cache_bypass  $http_cache_control;
+          add_header          X-Proxy-Cache $upstream_cache_status;
+          add_header          Cache-Control "public";
+
+          proxy_pass     http://localhost:3000/;
+
+          sub_filter_types text/html;
+          sub_filter_once off;
+          sub_filter '"appSubUrl":""' '"appSubUrl":"."';
+          sub_filter '"url":"/' '"url":"./';
+          sub_filter ':"/avatar/' ':"avatar/';
+
+          if ($request_filename ~ .*\.(?:js|css|jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm)$) {
+            expires             90d;
+          }
+        }
+      }
+    }

--- a/submitted/kk-grafana-cms/templates/rbac.yaml
+++ b/submitted/kk-grafana-cms/templates/rbac.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-sa
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-cr
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["*"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Chart.Name }}-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}-sa
+    namespace: {{.Release.Namespace }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Chart.Name }}-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Chart.Name }}-sa
+    namespace: {{.Release.Namespace }}

--- a/submitted/kk-grafana-cms/templates/secrets.yaml
+++ b/submitted/kk-grafana-cms/templates/secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cms-secret
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+type: Opaque
+data:
+  accessKeyId: {{ .Values.access_key_id | b64enc }}
+  accessSecret: {{ .Values.access_secret | b64enc}}
+  adminPass: {{ .Values.password | b64enc}}
+
+stringData:
+  datasources.yaml: |-
+    apiVersion: 1
+    deleteDatasources:
+     - name: CMS Grafana Service
+       orgId: 1
+    datasources:
+     - name: CMS Grafana Service
+       type: aliyun_cms_grafana_datasource
+       access: proxy
+       url: http://metrics.{{ .Values.region_id }}.aliyuncs.com
+       basicAuth: false
+       withCredentials: false
+       isDefault: true
+       jsonData:
+         cmsAccessKey: {{ .Values.access_key_id }}
+         cmsSecretKey: {{ .Values.access_secret }}
+         keepCookies: []
+       secureJsonFields: {}
+       readOnly: false

--- a/submitted/kk-grafana-cms/templates/service.yaml
+++ b/submitted/kk-grafana-cms/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kk-grafana-cms.fullname" . }}
+  labels:
+{{ include "kk-grafana-cms.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kk-grafana-cms.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/submitted/kk-grafana-cms/values.yaml
+++ b/submitted/kk-grafana-cms/values.yaml
@@ -1,0 +1,49 @@
+# Default values for kk-grafana-cms.
+
+replicaCount: 1
+
+plugins: grafana-clock-panel,ryantxu-ajax-panel,farski-blendstat-panel,grafana-simple-json-datasource,https://github.com/aliyun/aliyun-cms-grafana/archive/master.zip;aliyun-cms-grafana
+
+access_key_id: ""
+access_secret: ""
+region_id: cn-shanghai
+password: admin
+
+image:
+  repository: grafana/grafana
+  pullPolicy: IfNotPresent
+
+build_image:
+  repository: guoxudongdocker/grafana-build
+  tag: latest
+  pullPolicy: Always
+
+schedule: "30 2 * * *"
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: grafana.chart-example.local
+      paths: ['/']
+
+  tls: []
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+nodeSelector: {}
+
+affinity: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Sign our CLA.
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
新增 kk-grafana-cms helm chart，集成阿里云监控的grafana展示，只要启动时输入AK/AS，即可生成所有资源的监控图表，目前支持ECS、RDS、EIP、Redis监控dashboard
**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation (是否包含文档)
- [ ] this PR contains unit tests (是否包含测试、实际环境有效性验证)
- [x] this PR has been tested for backwards compatibility (是否向后兼容)