### PR TITLE
chore(schema-registry-ui): upgrade to new `apiVersion: apps/v1`

### DIFF
--- a/curated/schema-registry-ui/templates/deployment.yaml
+++ b/curated/schema-registry-ui/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "schema-registry-ui.fullname" . }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Sign our CLA.
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Just a small update. 😃

Got this error when try to deploy

```
Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "schema-registry-ui" namespace: "" from "": no matches for kind "Deployment" in version "apps/v1beta2"
```

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation (是否包含文档)
- [ ] this PR contains unit tests (是否包含测试、实际环境有效性验证)
- [ ] this PR has been tested for backwards compatibility (是否向后兼容)